### PR TITLE
Restricting results with Google Geosearch

### DIFF
--- a/GeoSearch/index.html
+++ b/GeoSearch/index.html
@@ -48,7 +48,9 @@
 //SMEIJER PLUGIN GIThttps://github.com/smeijer/L.GeoSearch
 //GOOGLE GEOCODING API https://developers.google.com/maps/documentation/geocoding/
 
-//...The types[] array in the result indicates the address type. Examples of address types include a street address, a country, or a political entity. There is also a types[] array in the address_components[], indicating the type of each part of the address. Examples include street number or country. (Below is a full list of types.) Addresses may have multiple types. The types may be considered 'tags'. For example, many cities are tagged with the political and the locality type.
+//...The types[] array in the result indicates the address type. Examples of address types include a street address, a country, or a political entity. There is also a types[] array in the address_components[], indicating the type of each part of the address.
+//Examples include street number or country. (Below is a full list of types.) Addresses may have multiple types. 
+//The types may be considered 'tags'. For example, many cities are tagged with the political and the locality type.
 
 //The following types are supported and returned by the geocoder in both the address type and address component type arrays:
 

--- a/GeoSearch/index.html
+++ b/GeoSearch/index.html
@@ -20,14 +20,14 @@
 		/**
 		 * get url paramaters
 		 */
-		function getURLParameter(name) {
-		    return decodeURI(
-		        (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,])[1]
-		    );
-		}
+		// function getURLParameter(name) {
+		//     return decodeURI(
+		//         (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,])[1]
+		//     );
+		// }
 
-		var regionParameter = getURLParameter('region');
-		var region = (regionParameter === 'undefined') ? '' : regionParameter;
+		// var regionParameter = getURLParameter('region');
+		// var region = (regionParameter === 'undefined') ? '' : regionParameter;
 
 		/** 
 		 * create map 
@@ -40,11 +40,54 @@
 			center: new L.LatLng(53.2, 5.8), zoom: 12 
 		});
 
-        new L.Control.GeoSearch({
-            provider: new L.GeoSearch.Provider.Google({
-            	region: region
-            })
-        }).addTo(map);
+       //OVERLAYS
+    
+//add leaflet geosearch plugin here
+//documentation: 
+    
+//SMEIJER PLUGIN GIThttps://github.com/smeijer/L.GeoSearch
+//GOOGLE GEOCODING API https://developers.google.com/maps/documentation/geocoding/
+
+//...The types[] array in the result indicates the address type. Examples of address types include a street address, a country, or a political entity. There is also a types[] array in the address_components[], indicating the type of each part of the address. Examples include street number or country. (Below is a full list of types.) Addresses may have multiple types. The types may be considered 'tags'. For example, many cities are tagged with the political and the locality type.
+
+//The following types are supported and returned by the geocoder in both the address type and address component type arrays:
+
+//street_address indicates a precise street address.
+//route indicates a named route (such as "US 101").
+//intersection indicates a major intersection, usually of two major roads.
+//political indicates a political entity. Usually, this type indicates a polygon of some civil administration.
+//country indicates the national political entity, and is typically the highest order type returned by the Geocoder.
+//administrative_area_level_1 indicates a first-order civil entity below the country level. Within the United States, these administrative levels are states. Not all nations exhibit these administrative levels.
+//administrative_area_level_2 indicates a second-order civil entity below the country level. Within the United States, these administrative levels are counties. Not all nations exhibit these administrative levels.
+//administrative_area_level_3 indicates a third-order civil entity below the country level. This type indicates a minor civil division. Not all nations exhibit these administrative levels.
+//administrative_area_level_4 indicates a fourth-order civil entity below the country level. This type indicates a minor civil division. Not all nations exhibit these administrative levels.
+//administrative_area_level_5 indicates a fifth-order civil entity below the country level. This type indicates a minor civil division. Not all nations exhibit these administrative levels.
+//colloquial_area indicates a commonly-used alternative name for the entity.
+//locality indicates an incorporated city or town political entity.
+//ward indicates a specific type of Japanese locality, to facilitate distinction between multiple locality components within a Japanese address.
+//sublocality indicates a first-order civil entity below a locality. For some locations may receive one of the additional types: sublocality_level_1 to sublocality_level_5. Each sublocality level is a civil entity. Larger numbers indicate a smaller geographic area.
+//neighborhood indicates a named neighborhood
+//premise indicates a named location, usually a building or collection of buildings with a common name
+//subpremise indicates a first-order entity below a named location, usually a singular building within a collection of buildings with a common name
+//postal_code indicates a postal code as used to address postal mail within the country.
+//natural_feature indicates a prominent natural feature.
+//airport indicates an airport.
+//park indicates a named park.
+//point_of_interest indicates a named point of interest. Typically, these "POI"s are prominent local entities that don't easily fit in another category, such as "Empire State Building" or "Statue of Liberty."//
+               
+
+//for our purpose, we can thus restrict the geosearch to location results in the locality that is Newark (note: this could be trickier with a more commmon place name)
+
+      new L.Control.GeoSearch({
+           provider: new L.GeoSearch.Provider.Google({
+               
+         
+
+               componentRestrictions: {"locality":"Newark"}
+
+           }),
+           position: 'topcenter'
+       }).addTo(map);
 		
 	</script>
 </body>


### PR DESCRIPTION
Thanks so much for this very necessary plugin. When using it on a project for the Planning Office of Newark recently, I had trouble restricting the results using the getURLParameter function. The fix for me was found in the Google Geocoding API. I've commented out the componentRestrictions available with this API and am successfully testing with: componentRestrictions: {"locality":"Newark"}